### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See the following for build arguments and running locally.
 |BuildConfiguration|The configuration to run the build, **Debug** or **Release** |*Release*|All|Optional|
 |PreReleaseSuffix|The pre-release suffix for versioning nuget package artifacts e.g. `beta`|*ci*|All|Optional|
 |CoverWith|**DotCover** or **OpenCover** to calculate and report code coverage, **None** to skip. When not **None**, a coverage file and html report will be generated at `./artifacts/coverage`|*OpenCover*|Windows Only|Optional|
-|SkipCodeInspect|**false** to run ReSharper code inspect and report results, **true** to skip. When **true**, the code inspection html report and xml output will be generated at `./artifacts/resharper-reports`|*false*|Windows Only|Optional|
+|SkipCodeInspect|**false** to run ReSharper code inspect and report results, **true** to skip. When **false**, the code inspection html report and xml output will be generated at `./artifacts/resharper-reports`|*false*|Windows Only|Optional|
 |BuildNumber|The build number to use for pre-release versions|*0*|All|Optional|
 |LinkSources|[Source link](https://github.com/ctaggart/SourceLink) support allows source code to be downloaded on demand while debugging|*true*|All|Optional|
 


### PR DESCRIPTION
I believe it should be, When false, the code inspection html report and xml output will be generate at...
Currently it says When true,... which does not make sense because true disables the report generation.

This is not an issue with App.Metrics and so all answers related to the normal format would be N/A since its not a code change, just a documentation change.

Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidlines](https://github.com/alhardy/AppMetrics/blob/master/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

-  N/A

### Details on the issue fix or feature implementation

- The documentation looks to be incorrect.


### Confirm the following

- N/A